### PR TITLE
Added an option to --skip-cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Especially useful to use on CI to test against multiple `ember` versions.
 
 #### `ember try <scenario> <command (Default: test)>`
 
-This command will run any `ember-cli` command with the specified scenario. The command will default to `ember test`. 
+This command will run any `ember-cli` command with the specified scenario. The command will default to `ember test`.
 
 For example:
 
@@ -37,13 +37,19 @@ or
   ember try ember-1.11-with-ember-data-beta-16 serve
 ```
 
+When running in a CI environment where changes are discarded you can skip reseting your environment back to its original state by specifying --skip-cleanup as an option to ember try.
+
+```
+  ember try ember-1.11 test --skip-cleanup
+```
+
 #### `ember try:reset`
 
 This command restores the original `bower.json` from `bower.json.ember-try`, `rm -rf`s `bower_components` and runs `bower install`. For use if any of the other commands fail to clean up after (they run this by default on completion).
 
 ### Config
 
-Configuration will be read from a file in your ember app in `config/ember-try.js`. It should look like: 
+Configuration will be read from a file in your ember app in `config/ember-try.js`. It should look like:
 
 ```js
 module.exports = {
@@ -82,7 +88,7 @@ module.exports = {
 
 Scenarios are sets of dependencies (`bower` only). They can be specified exactly as in the `bower.json`
 The `name` can be used to try just one scenario using the `ember try` command.
- 
+
 If no `config/ember-try.js` file is present, the default config will be used. This is the current default config:
 
 ```js
@@ -110,7 +116,7 @@ If no `config/ember-try.js` file is present, the default config will be used. Th
 }
 ```
 
-See an example of using `ember-try` for CI [here](https://github.com/kategengler/ember-feature-flags/commit/aaf0226975c76630c875cf6b923fdc23b025aa79), and the resulting build [output](https://travis-ci.org/kategengler/ember-feature-flags/builds/55597086). 
+See an example of using `ember-try` for CI [here](https://github.com/kategengler/ember-feature-flags/commit/aaf0226975c76630c875cf6b923fdc23b025aa79), and the resulting build [output](https://travis-ci.org/kategengler/ember-feature-flags/builds/55597086).
 
 ### Special Thanks
 

--- a/lib/commands/try.js
+++ b/lib/commands/try.js
@@ -10,6 +10,10 @@ module.exports = {
     '<command (Default: test)>'
   ],
 
+  availableOptions: [
+    { name: 'skip-cleanup',  type: Boolean, default: false },
+  ],
+
   getCommand: function() {
     var args = process.argv.slice();
     var tryIndex = args.indexOf(this.name);
@@ -46,7 +50,7 @@ module.exports = {
       config: config
     });
 
-    return tryTask.run(scenario, commandArgs);
+    return tryTask.run(scenario, commandArgs, commandOptions);
   }
 };
 

--- a/lib/tasks/try.js
+++ b/lib/tasks/try.js
@@ -7,7 +7,7 @@ var BowerHelpers    = require('../utils/bower-helpers');
 var findEmberPath   = require('./../utils/find-ember-path');
 
 module.exports = CoreObject.extend({
-  run: function(scenario, commandArgs){
+  run: function(scenario, commandArgs, commandOptions){
     var task = this;
 
     process.on('SIGINT', function() {
@@ -35,7 +35,16 @@ module.exports = CoreObject.extend({
             });
         })
         .then(function(result){
-          return BowerHelpers.cleanup(task.project.root).then(function(){
+          var promise;
+          if(commandOptions.skipCleanup){
+            //create a fake promise for consistency
+            promise = new RSVP.Promise(function(resolve) {
+              resolve();
+            });
+          } else {
+            promise = BowerHelpers.cleanup(task.project.root);
+          }
+          return promise.then(function(){
             if(!result){
               task.ui.writeLine('');
               task.ui.writeLine('ember ' + commandName + ' with scenario ' + scenario.name + ' exited nonzero');


### PR DESCRIPTION
When running in a CI environment like travis the cleanup is just extra
time wasted.  —skip-cleanup will prevent the reset from running.

I only added this to the try command, if you want I’m happy to add it to testall as well.
